### PR TITLE
fix: avoid Cannot read property 'errorName' of null

### DIFF
--- a/src/ngxerror.directive.ts
+++ b/src/ngxerror.directive.ts
@@ -36,7 +36,7 @@ export class NgxErrorDirective implements OnInit, OnDestroy, DoCheck {
   hidden: boolean = true;
 
   rules: string[] = [];
-  
+
   errorNames: string[] = [];
 
   subscription: Subscription;
@@ -48,14 +48,14 @@ export class NgxErrorDirective implements OnInit, OnDestroy, DoCheck {
   constructor(
     @Inject(forwardRef(() => NgxErrorsDirective)) private ngxErrors: NgxErrorsDirective
   ) {}
-  
+
   ngOnInit() {
 
     this._states = new Subject<string[]>();
     this.states = this._states.asObservable().distinctUntilChanged();
 
     const errors = this.ngxErrors.subject
-      .filter(obj => this.errorNames.includes(obj.errorName));
+      .filter(obj => obj && this.errorNames.includes(obj.errorName));
 
     const states = this.states
       .map(states => this.rules.every(rule => states.includes(rule)));


### PR DESCRIPTION
<!-- Nice one! You're submitting a pull request. Please give us as much information as possible to help get it merged quicker! -->

**What are you adding/fixing?**
<!-- For example, you might be fixing a bug, adding a new feature or refactoring some code. Please link to the relevant issue here as well! -->

NgErrorsDirective.subject is BehaviourSubject and initial value is null.
So there is a time to access nullObject at NgErrorDirective.

**Have you added tests for your changes?**
<!-- Adding tests is greatly appreciated! For all new features, tests are required. -->

No

**Will this need documentation changes?**
<!-- If yes, docs will need to be changed (not necessarily by you!) before this can get merged. If you've changed the docs (you're awesome), say so here. If not (don't worry, you're still awesome), feel free to submit your PR still and someone will come along and write them up -->

No

**Does this introduce a breaking change?**
<!-- If your change make a breaking change, please include as much information as possible and the reasoning behind the changes -->

No

**Other information**