### PR TITLE
feature: support form errors (see issue #15)

### DIFF
--- a/src/ngxerror.directive.ts
+++ b/src/ngxerror.directive.ts
@@ -58,14 +58,23 @@ export class NgxErrorDirective implements OnInit, OnDestroy, DoCheck {
 
     this.subscription = Observable.combineLatest(states, errors)
       .subscribe(([states, errors]) => {
-        this.hidden = !(states && errors.control.hasError(errors.errorName));
+        if (errors.control) {
+          this.hidden = !(states && errors.control.hasError(errors.errorName));
+        } else {
+          this.hidden = !(states && errors.form.hasError(errors.errorName));
+        }
       });
 
   }
 
   ngDoCheck() {
     this._states.next(
-      this.rules.filter((rule) => (this.ngxErrors.control as any)[rule])
+      this.rules.filter((rule) => {
+        if (this.ngxErrors.control) {
+          return (this.ngxErrors.control as any)[rule];
+        }
+        return (this.ngxErrors.form as any)[rule];
+      })
     );
   }
 

--- a/src/ngxerrors.ts
+++ b/src/ngxerrors.ts
@@ -1,8 +1,9 @@
-import { AbstractControl } from '@angular/forms';
+import { AbstractControl, FormGroupDirective } from '@angular/forms';
 
 export type ErrorOptions = string | string[];
 
 export interface ErrorDetails {
-  control: AbstractControl,
+  control?: AbstractControl,
+  form?: FormGroupDirective,
   errorName: string
 }


### PR DESCRIPTION
<!-- Nice one! You're submitting a pull request. Please give us as much information as possible to help get it merged quicker! -->

**What are you adding/fixing?**
<!-- For example, you might be fixing a bug, adding a new feature or refactoring some code. Please link to the relevant issue here as well! -->
I love the syntax of ngxErrors so much, that I wanted to use it not just for form control errors, but for form errors itself. See issue #15 

**Have you added tests for your changes?**
<!-- Adding tests is greatly appreciated! For all new features, tests are required. -->
I'm sorry, I did not. But the existing tests still passed.

**Will this need documentation changes?**
<!-- If yes, docs will need to be changed (not necessarily by you!) before this can get merged. If you've changed the docs (you're awesome), say so here. If not (don't worry, you're still awesome), feel free to submit your PR still and someone will come along and write them up -->
Yes, I imagine this feature is something ppl would want to know about.

**Does this introduce a breaking change?**
<!-- If your change make a breaking change, please include as much information as possible and the reasoning behind the changes -->
I don't think so. As far as I can tell, all existing functionality still remains.

**Other information**
This code is a bit ugly, not super DRY. I sort of intended it as a proof of concept. It could be cleaned up and refactored, maybe we need a concept of a single object that can be either a form control or a form group. I'm especially displeased with having to call `detectChanges()` but I haven't found a way around it for OnPush change detection strategy. If anybody knows how to avoid it, pls let me know, I want to learn.

Thanks @toddmotto for a great project!
